### PR TITLE
Make host/port configurable via environment variables

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -17,8 +17,8 @@ const app = express();
 const http = require('http').createServer(app);
 
 // Change this to address of the Rasp Pi
-const host = '0.0.0.0'; //'192.168.1.164'
-const port = 80;
+const host = process.env.HOST || '0.0.0.0'; //'192.168.1.164'
+const port = process.env.PORT || 80;
 
 /* PREMADE VIDEOS */
 const WAIT_VIDEO = "wait.mp4";


### PR DESCRIPTION
PR makes the host and port variables configurable through environment variables. The default values remain the same with 0.0.0.0 for host and 80 for port. This is the way I usually do configuration management, I think it's easier than exposing everything through a command line interface. But it's up to ya'll if you want to use it or not.