### PR TITLE
Clean directory if it exists instead of remove

### DIFF
--- a/camera/camera.py
+++ b/camera/camera.py
@@ -11,12 +11,19 @@ def fresh_dir(path):
 
     # Overwrite
     if os.path.exists(path):
-        shutil.rmtree(path)
-        print("Deleted existing directory: {}".format(path))
-
-    # Make
-    os.mkdir(path)
-    print("Created new directory: {}".format(path))
+        for f in os.listdir(path):
+            p = os.path.join(path, f)
+            try:
+                shutil.rmtree(p)
+                print("Removed directory: {}".format(f))
+            except OSError:
+                os.remove(p)
+                print("Removed file: {}".format(f))
+        print("Cleaned Directory: {}".format(path))
+    else:
+        # Make
+        os.mkdir(path)
+        print("Created new directory: {}".format(path))
 
 # Main script
 if __name__ == "__main__":


### PR DESCRIPTION
PR changes the logic of `fresh_dir()` to clean the contents of the directory if it exists instead of removing it. The reason for this is that `DxiWiFi` installs an event listener for a specific directory and if it is deleted the event listener will never fire when a new file is created. 