### PR TITLE
.deb package for camera

### DIFF
--- a/camera/CMakeLists.txt
+++ b/camera/CMakeLists.txt
@@ -31,7 +31,12 @@ set(CPACK_DEBIAN_PACKAGE_HOMEPAGE "https://github.com/oresat/oresat-live-softwar
 execute_process(COMMAND dpkg --print-architecture OUTPUT_VARIABLE CPACK_DEBIAN_PACKAGE_ARCHITECTURE OUTPUT_STRIP_TRAILING_WHITESPACE)
 
 # RX component CPack config
-set(CPACK_DEBIAN_CAMERA_FILE_NAME "${CPACK_PACKAGE_NAME}_${CPACK_PACKAGE_VERSION}_${CPACK_DEBIAN_PACKAGE_ARCHITECTURE}.deb")
+string(CONCAT CPACK_DEBIAN_CAMERA_FILE_NAME
+    "${CPACK_PACKAGE_NAME}_"
+    "${CPACK_PACKAGE_VERSION}_"
+    "${CPACK_DEBIAN_PACKAGE_ARCHITECTURE}.deb"
+    )
+
 include(CPack)
 set(CAPTURE_DESCRIPTION "OreSat Live Software camera capture program")
 file(GLOB sources ./*)

--- a/camera/CMakeLists.txt
+++ b/camera/CMakeLists.txt
@@ -1,7 +1,55 @@
 cmake_minimum_required(VERSION 3.2)
 project(camera)
+set(ORESATLIVESW_VERSION_MAJOR "0")
+set(ORESATLIVESW_VERSION_MINOR "0")
+set(ORESATLIVESW_VERSION_PATCH "0")
+set(ORESATLIVESW_VERSION_REVISION "1")
+string(CONCAT CPACK_PACKAGE_VERSION
+    "${ORESATLIVESW_VERSION_MAJOR}."
+    "${ORESATLIVESW_VERSION_MINOR}."
+    "${ORESATLIVESW_VERSION_PATCH}-"
+    "${ORESATLIVESW_VERSION_REVISION}"
+    )
+# Include and output directories
+include_directories(
+    ${PROJECT_SOURCE_DIR}
+)
+set(ORESATLIVESW_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/bin/${CMAKE_BUILD_TYPE})
 
+# Global CPack configuration
+set(CPACK_GENERATOR "DEB")
+set(CPACK_PACKAGE_NAME "oresat-live-software-camera")
+set(CPACK_PACKAGE_CONTACT "PSAS <oresat@pdx.edu>")
+set(CPACK_DEBIAN_PACKAGE_DESCRIPTION "Oresat Live Software")
+set(CPACK_DEBIAN_PACKAGE_SECTION "net")
+set(CPACK_DEBIAN_PACKAGE_DEPENDS "libv4l-dev (>= 1.16.3-3), iw")
+set(CPACK_DEB_COMPONENT_INSTALL ON)
+set(CPACK_DEBIAN_ENABLE_COMPONENT_DEPENDS ON)
+set(CPACK_DEBIAN_PACKAGE_HOMEPAGE "https://github.com/oresat/oresat-live-software")
+
+# use host architecture
+execute_process(COMMAND dpkg --print-architecture OUTPUT_VARIABLE CPACK_DEBIAN_PACKAGE_ARCHITECTURE OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+# RX component CPack config
+set(CPACK_DEBIAN_CAMERA_FILE_NAME "${CPACK_PACKAGE_NAME}_${CPACK_PACKAGE_VERSION}_${CPACK_DEBIAN_PACKAGE_ARCHITECTURE}.deb")
+include(CPack)
+set(CAPTURE_DESCRIPTION "OreSat Live Software camera capture program")
 file(GLOB sources ./*)
-
 add_executable(capture ${sources})
 target_link_libraries(capture v4l1 v4l2)
+set_target_properties( capture
+    PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY ${ORESATLIVESW_RUNTIME_OUTPUT_DIRECTORY}
+    )
+install(
+    TARGETS capture
+    DESTINATION /usr/bin
+    PERMISSIONS OWNER_WRITE OWNER_READ OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
+    COMPONENT CAPTURE
+    )
+cpack_add_component(
+    CAPTURE
+    DISPLAY_NAME CAPTURE
+    DESCRIPTION ${CAPTURE_DESCRIPTION}
+    GROUP CAPTURE
+    )


### PR DESCRIPTION
Example package build on BBB:
```
debian@beaglebone:~/src/oresat-live-software$ cd camera/
debian@beaglebone:~/src/oresat-live-software/camera$ rm -rf build
debian@beaglebone:~/src/oresat-live-software/camera$ mkdir build
debian@beaglebone:~/src/oresat-live-software/camera$ cd build
debian@beaglebone:~/src/oresat-live-software/camera/build$ cmake ..
-- The C compiler identification is GNU 8.3.0
-- The CXX compiler identification is GNU 8.3.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
-- Generating done
-- Build files have been written to:
/home/debian/src/oresat-live-software/camera/build
debian@beaglebone:~/src/oresat-live-software/camera/build$ make
Scanning dependencies of target capture
[ 50%] Building C object CMakeFiles/capture.dir/capture.c.o
[100%] Linking C executable ../bin/capture
[100%] Built target capture
debian@beaglebone:~/src/oresat-live-software/camera/build$ make package
[100%] Built target capture
Run CPack packaging tool...
CPack: Create package using DEB
CPack: Install projects
CPack: - Run preinstall target for: camera
CPack: - Install project: camera
CPack: -   Install component: CAPTURE
CPack: Create package
CPack: - package:
/home/debian/src/oresat-live-software/camera/build/oresat-live-software-camera-0.0.0-1-Linux-CAPTURE.deb
generated.
debian@beaglebone:~/src/oresat-live-software/camera/build$ sudo dpkg -i
*.deb
(Reading database ... 77771 files and directories currently installed.)
Preparing to unpack
oresat-live-software-camera-0.0.0-1-Linux-CAPTURE.deb ...
Unpacking oresat-live-software-camera-capture (0.0.0-1) over (0.0.0-1)
...
Setting up oresat-live-software-camera-capture (0.0.0-1) ...
debian@beaglebone:~/src/oresat-live-software/camera/build$ apt depends
oresat-live-software-camera-capture
oresat-live-software-camera-capture
  Depends: libv4l-dev (>= 1.16.3-3)
  Depends: iw
debian@beaglebone:~/src/oresat-live-software/camera/build$  dpkg-query
-S /usr/bin/capture
oresat-live-software-camera-capture: /usr/bin/capture
```